### PR TITLE
Version 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,15 @@ php:
   - 7.1
   - 7.2
 
-before_script:
-  - travis_retry composer install --no-interaction --prefer-dist
+env:
+    - COMPOSER_ARGS=""
+    - COMPOSER_ARGS="--prefer-stable"
+    - COMPOSER_ARGS="--prefer-stable --prefer-lowest"
+
+install:
+  - travis_retry composer update --no-interaction --prefer-dist $COMPOSER_ARGS
 
 script:
-  - ./vendor/bin/tester -p php -s -j 32 ./tests
+  - vendor/bin/tester -p php -s -j 32 tests
+  - vendor/bin/phpstan.phar analyse -l 7 -c tests/phpstan.neon src
+  - vendor/bin/phpcs --standard=vendor/damejidlo/coding-standard/DameJidloCodingStandard/ruleset.xml --ignore=tests/tmp/* --encoding=utf-8 src tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
+  - 7.1
+  - 7.2
 
 before_script:
-  - composer self-update || echo "[ERROR] update-composer failed!"
-  - composer install --no-interaction --optimize-autoloader
+  - travis_retry composer install --no-interaction --prefer-dist
 
 script:
   - ./vendor/bin/tester -p php -s -j 32 ./tests

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,13 @@
 	"type": "library",
 	"require": {
 		"php": ">=7.1",
-		"nette/utils": "^2.4 || ^3.0"
+		"nette/utils": "^2.4@dev || ^3.0@dev"
 	},
 	"require-dev": {
-		"nette/tester": "^2.0.0"
+		"damejidlo/coding-standard": "^0.7.0",
+		"nette/tester": "^2.0.0",
+		"phpstan/phpstan-shim": "^0.9",
+		"phpstan/phpstan-strict-rules": "^0.9"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
 	"description": "",
 	"type": "library",
 	"require": {
-		"php": ">=7.1"
+		"php": ">=7.1",
+		"nette/utils": "^2.4 || ^3.0"
 	},
 	"require-dev": {
 		"nette/tester": "^2.0.0"

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
 	"description": "",
 	"type": "library",
 	"require": {
-		"php": ">= 5.6.0"
+		"php": ">=7.1"
 	},
 	"require-dev": {
-		"nette/tester": "^1.6.1"
+		"nette/tester": "^2.0.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/DateTimeFactory.php
+++ b/src/DateTimeFactory.php
@@ -8,6 +8,9 @@ use Nette\Utils\DateTime;
 
 
 
+/**
+ * @deprecated
+ */
 class DateTimeFactory
 {
 

--- a/src/DateTimeFactory.php
+++ b/src/DateTimeFactory.php
@@ -3,12 +3,17 @@ declare(strict_types = 1);
 
 namespace Damejidlo\DateTimeFactory;
 
-use DateTime;
+use Nette\SmartObject;
+use Nette\Utils\DateTime;
 
 
 
 class DateTimeFactory
 {
+
+	use SmartObject;
+
+
 
 	/**
 	 * @return DateTime

--- a/src/DateTimeFactory.php
+++ b/src/DateTimeFactory.php
@@ -19,6 +19,7 @@ class DateTimeFactory
 
 
 	/**
+	 * @deprecated
 	 * @return DateTime
 	 */
 	public function getNow() : DateTime

--- a/src/DateTimeFactory.php
+++ b/src/DateTimeFactory.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Damejidlo\DateTimeFactory;
 
@@ -12,7 +13,7 @@ class DateTimeFactory
 	/**
 	 * @return DateTime
 	 */
-	public function getNow()
+	public function getNow() : DateTime
 	{
 		return new DateTime();
 	}

--- a/src/DateTimeImmutableFactory.php
+++ b/src/DateTimeImmutableFactory.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Damejidlo\DateTimeFactory;
 
@@ -12,7 +13,7 @@ class DateTimeImmutableFactory
 	/**
 	 * @return DateTimeImmutable
 	 */
-	public function getNow()
+	public function getNow() : DateTimeImmutable
 	{
 		return new DateTimeImmutable();
 	}

--- a/src/DateTimeImmutableFactory.php
+++ b/src/DateTimeImmutableFactory.php
@@ -4,11 +4,16 @@ declare(strict_types = 1);
 namespace Damejidlo\DateTimeFactory;
 
 use DateTimeImmutable;
+use Nette\SmartObject;
 
 
 
 class DateTimeImmutableFactory
 {
+
+	use SmartObject;
+
+
 
 	/**
 	 * @return DateTimeImmutable

--- a/tests/DateTimeFactoryTest.phpt
+++ b/tests/DateTimeFactoryTest.phpt
@@ -6,7 +6,7 @@ namespace Damejidlo\DateTimeFactory\Tests;
 require_once __DIR__ . '/bootstrap.php';
 
 use Damejidlo\DateTimeFactory\DateTimeFactory;
-use DateTime;
+use Nette\Utils\DateTime;
 use Tester\Assert;
 use Tester\TestCase;
 

--- a/tests/DateTimeFactoryTest.phpt
+++ b/tests/DateTimeFactoryTest.phpt
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Damejidlo\DateTimeFactory\Tests;
 
@@ -17,7 +18,7 @@ use Tester\TestCase;
 class DateTimeFactoryTest extends TestCase
 {
 
-	public function testType()
+	public function testType() : void
 	{
 		$dateTimeFactory = new DateTimeFactory();
 
@@ -29,7 +30,7 @@ class DateTimeFactoryTest extends TestCase
 
 
 
-	public function testGetNow()
+	public function testGetNow() : void
 	{
 		$dateTimeFactory = new DateTimeFactory();
 

--- a/tests/DateTimeImmutableFactoryTest.phpt
+++ b/tests/DateTimeImmutableFactoryTest.phpt
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Damejidlo\DateTimeFactory\Tests;
 
@@ -17,7 +18,7 @@ use Tester\TestCase;
 class DateTimeImmutableTest extends TestCase
 {
 
-	public function testType()
+	public function testType() : void
 	{
 		$dateTimeFactory = new DateTimeImmutableFactory();
 
@@ -29,7 +30,7 @@ class DateTimeImmutableTest extends TestCase
 
 
 
-	public function testGetNow()
+	public function testGetNow() : void
 	{
 		$dateTimeFactory = new DateTimeImmutableFactory();
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
+declare(strict_types = 1);
 
-namespace DamejidloTests\NewRelic;
+namespace Damejidlo\DateTimeFactory\Tests;
 
 require __DIR__ . '/../vendor/autoload.php';
 

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -1,0 +1,2 @@
+includes:
+	- ../vendor/phpstan/phpstan-strict-rules/rules.neon


### PR DESCRIPTION
- Drop PHP 5.6 and 7.0 support.
- Use strict types and return types.
- Revert removal of nette/utils.
- `DateTimeFactory` is deprecated, use `DateTimeImmutableFactory` instead
- Use phpstan in CI build.
- Use damejidlo/coding-standard in CI build.